### PR TITLE
Fix sendgrid cc and bcc

### DIFF
--- a/espwrap/adaptors/sendgrid_v3.py
+++ b/espwrap/adaptors/sendgrid_v3.py
@@ -121,7 +121,7 @@ class SendGridMassEmail(MassEmail):
 
         # BCC
         if self.bcc_list:
-            list_bcc = [Bcc(email) for email in self.cc_list]
+            list_bcc = [Bcc(email) for email in self.bcc_list]
             message.bcc = list_bcc
 
         # Attachment

--- a/espwrap/adaptors/sendgrid_v3.py
+++ b/espwrap/adaptors/sendgrid_v3.py
@@ -114,16 +114,6 @@ class SendGridMassEmail(MassEmail):
         if self.ip_pool:
             message.ip_pool_name = IpPoolName(self.ip_pool)
 
-        # CC
-        if self.cc_list:
-            list_cc = [Cc(email) for email in self.cc_list]
-            message.cc = list_cc
-
-        # BCC
-        if self.bcc_list:
-            list_bcc = [Bcc(email) for email in self.bcc_list]
-            message.bcc = list_bcc
-
         # Attachment
         if self.attachments:
             for file_name, file_path_or_string in self.attachments.items():
@@ -192,6 +182,15 @@ class SendGridMassEmail(MassEmail):
                 )
 
         message.add_to(to_emails, is_multiple=True)
+
+        #CC and BCC
+        for personalization in message.personalizations:
+            if self.cc_list:
+                for cc_email in self.cc_list:
+                    personalization.add_cc(Cc(cc_email))
+            if self.bcc_list:
+                for bcc_email in self.bcc_list:
+                    personalization.add_bcc(Bcc(bcc_email))
 
         # Global Subs
         for key, val in self.global_merge_vars.items():

--- a/tests/test_sendgrid_v3.py
+++ b/tests/test_sendgrid_v3.py
@@ -134,6 +134,9 @@ def test_message_construction():
 
     delims = me.get_variable_delimiters()
 
+    me.add_cc("testcc@spam.com")
+    me.add_bcc("testbcc@spam.com")
+
     grouped_recipients = batch(list(me.recipients), me.partition)
 
     for grp in grouped_recipients:
@@ -141,6 +144,7 @@ def test_message_construction():
         to_send = breakdown_recipients(grp)
 
         message = me.message_constructor(to_send)
+       
         message_dict = message.get()
 
         print(message_dict)
@@ -157,6 +161,14 @@ def test_message_construction():
         assert message_dict["personalizations"][1]["to"][0]["email"] == "spam2@spam.com"
         assert message_dict["personalizations"][2]["to"][0]["name"] == "Josh"
         assert message_dict["personalizations"][2]["to"][0]["email"] == "spam@spam.com"
+
+        assert message_dict["personalizations"][0]["cc"][0]["email"] == "testcc@spam.com"
+        assert message_dict["personalizations"][1]["cc"][0]["email"] == "testcc@spam.com"
+        assert message_dict["personalizations"][2]["cc"][0]["email"] == "testcc@spam.com"
+        assert message_dict["personalizations"][0]["bcc"][0]["email"] == "testbcc@spam.com"
+        assert message_dict["personalizations"][1]["bcc"][0]["email"] == "testbcc@spam.com"
+        assert message_dict["personalizations"][2]["bcc"][0]["email"] == "testbcc@spam.com"
+        
 
         company_name_key = delims[0] + "COMPANY_NAME" + delims[1]
         assert message_dict["personalizations"][0]["substitutions"][company_name_key] == "UnitTest Spam Corp the Second"

--- a/tests/test_sendgrid_v3.py
+++ b/tests/test_sendgrid_v3.py
@@ -144,7 +144,6 @@ def test_message_construction():
         to_send = breakdown_recipients(grp)
 
         message = me.message_constructor(to_send)
-       
         message_dict = message.get()
 
         print(message_dict)
@@ -169,7 +168,6 @@ def test_message_construction():
         assert message_dict["personalizations"][1]["bcc"][0]["email"] == "testbcc@spam.com"
         assert message_dict["personalizations"][2]["bcc"][0]["email"] == "testbcc@spam.com"
         
-
         company_name_key = delims[0] + "COMPANY_NAME" + delims[1]
         assert message_dict["personalizations"][0]["substitutions"][company_name_key] == "UnitTest Spam Corp the Second"
         assert message_dict["personalizations"][1]["substitutions"][company_name_key] == "UnitTest Spam Corp the Second"


### PR DESCRIPTION
Resolves a few interrelated issues with adding CC and BCC addresses to messages using the sendgrid V3 adapter:

1. When using `add_bcc()`, messages are never delivered to the bcc address
2. When using `add_cc()`, sendgrid returns a `400` Bad Response error with the following: `Each email address in the personalization block should be unique between to, cc, and bcc. We found the first duplicate instance of [email@example.com] in the personalizations.1.bcc field`

The two issues above come from a tiny typo, where the section for handling bccs in the `message_constructor` leads to pulling emails from the _cc list_ instead of the _bcc_ list (line 124)

```
if self.bcc_list:
    list_bcc = [Bcc(email) for email in self.cc_list]
    message.bcc = list_bcc
```

Fixing those issues then leads to:

3. When using `add_cc()` or `add_bcc()`, sendgrid returns a `400` Bad Request error with the following: `The to array is required for all personalization objects, and must have at least one email object with a valid email address.`

This is caused by using the `add_to` function with `is_multiple=True`, which causes sendgrid to create a new `Personalization` for each recipient of the email message. In that case then, the bcc and cc fields need to be added on to each of the _personalization_ objects, not the message object, so this reworks the logic to do that ([semi-related StackOverflow example](https://stackoverflow.com/questions/71116589/with-sendgrid-and-python-how-to-send-an-email-to-multiple-bcc-at-once).)

Also for now chose to keep the `is_multiple=True` behavior and work around it rather than another approach, to keep things as consistent as possible to how it works today (just with bcc and cc working); there certainly may be a more elegant sendgrid-approved approach! Also added a quick little cc/bcc addendum to the existing test for `message_constructor`

(For SpotOn internal users, this is for jira ticket CSVC-520, discovered while working on CSVC-381 )